### PR TITLE
Fix btn-phone rendering when phone is empty (refs #14)

### DIFF
--- a/movecar.js
+++ b/movecar.js
@@ -699,10 +699,10 @@ function renderMainPage(origin) {
           <span>🔔</span>
           <span>再次通知</span>
         </button>
-        <a href="tel:${phone}" class="btn-phone">
+        ${phone ? `<a href="tel:${phone}" class="btn-phone">
           <span>📞</span>
           <span>直接打电话</span>
-        </a>
+        </a>` : ''}
       </div>
     </div>
 


### PR DESCRIPTION
Fixes #14 

Title
  Fix phone button rendering when no phone is configured

  What
  - Render the “直接打电话” button only when phone is present
  - Prevent empty tel: links in the main page action area

  Why
  - Avoid showing a non-functional call button when no phone number is set (issue #14)

  How
  - Wrap the phone anchor in a conditional template so it’s omitted when phone is falsy

  Testing
  - [x] Not run (manual verification recommended)